### PR TITLE
Fixed issue with Room Maintenance Page not displaying all room tasks.

### DIFF
--- a/src/app/logged-in/maintenance/maintenance-room-level/maintenance-room-level.component.html
+++ b/src/app/logged-in/maintenance/maintenance-room-level/maintenance-room-level.component.html
@@ -25,7 +25,4 @@
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-
-<mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
-
 </table>

--- a/src/app/logged-in/maintenance/maintenance-room-level/maintenance-room-level.component.ts
+++ b/src/app/logged-in/maintenance/maintenance-room-level/maintenance-room-level.component.ts
@@ -5,7 +5,7 @@ import { MaintenanceRoomService } from '../../../shared/api-services/maintenance
 import { DialogService } from '../../../shared/dialogs.service';
 import { Observable } from 'rxjs';
 import { RoomMaintenance } from '../../../shared/models/roomMaintenance';
-import { MatTableDataSource, MatPaginator, MatSort } from '@angular/material';
+import { MatTableDataSource, MatSort } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
 
 @Component({
@@ -15,7 +15,6 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class MaintenanceRoomLevelComponent implements OnInit {
 
-  @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
   @Input() roomId;
   
@@ -34,7 +33,6 @@ export class MaintenanceRoomLevelComponent implements OnInit {
         this.maintenanceRoomService.getRoomTasksByRoomId(this.roomId).subscribe(
           tasksForSelectedRoom => {
             this.dataSource = new MatTableDataSource(tasksForSelectedRoom);
-            this.dataSource.paginator = this.paginator;
             this.dataSource.sort = this.sort;
           }
         )


### PR DESCRIPTION
#50 
Removed the paginator because it was invisible and also limiting our room tasks to 5 entries. I don't believe that we need a paginator for this page because Ron likely won't have more than 10 tasks overall per room. 